### PR TITLE
Fix tests to pass after 2021-06-09

### DIFF
--- a/t/examples.t
+++ b/t/examples.t
@@ -38,7 +38,7 @@ subtest "wrong path" => sub {
 
 subtest "expiration" => sub {
     $jar->clear;
-    $jar->add( $req, "lang=en-US; Expires=Wed, 09 Jun 2021 10:18:14 GMT" );
+    $jar->add( $req, "lang=en-US; Expires=Wed, 09 Jun 9999 10:18:14 GMT" );
     is( $jar->cookie_header($req), "lang=en-US" );
     $jar->add( $req, "lang=; Expires=Sun, 06 Nov 1994 08:49:37 GMT" );
     is( $jar->cookie_header($req), "" );


### PR DESCRIPTION
Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future.
The usual offset is +15 years, because that is how long I expect some software will be used in some places.
This showed up failing tests in our package build.
See https://reproducible-builds.org/ for why this matters.